### PR TITLE
MAX: Declare libc function stubs as weak

### DIFF
--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32520/Source/system_max32520.c
@@ -39,12 +39,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32570/Source/system_max32570.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_max32572.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32572/Source/system_riscv_max32572.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32650/Source/system_max32650.c
@@ -38,12 +38,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_max32655.c
@@ -37,12 +37,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32655/Source/system_riscv_max32655.c
@@ -38,12 +38,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32660/Source/system_max32660.c
@@ -41,12 +41,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -40,12 +40,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32665/Source/system_max32665.c
@@ -43,12 +43,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32670/Source/system_max32670.c
@@ -37,12 +37,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32672/Source/system_max32672.c
@@ -35,12 +35,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32675/Source/system_max32675.c
@@ -37,12 +37,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_max32680.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32680/Source/system_riscv_max32680.c
@@ -38,12 +38,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_max32690.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32690/Source/system_riscv_max32690.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_max78000.c
@@ -36,12 +36,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX78000/Source/system_riscv_max78000.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_max78002.c
@@ -35,12 +35,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX78002/Source/system_riscv_max78002.c
@@ -33,12 +33,12 @@ The libc implementation from GCC 11+ depends on _getpid and _kill in some places
 There is no concept of processes/PIDs in the baremetal PeriphDrivers, therefore
 we implement stub functions that return an error code to resolve linker warnings.
 */
-int _getpid(void)
+__weak int _getpid(void)
 {
     return E_NOT_SUPPORTED;
 }
 
-int _kill(void)
+__weak int _kill(void)
 {
     return E_NOT_SUPPORTED;
 }


### PR DESCRIPTION
Declares _getpid() and _kill() function stubs as weak to avoid conflicting with similar function stubs defined in zephyr libc-hooks. This fixes linker errors when building zephyr with newlib on max32 boards.