### PR TITLE
MSDK: MAX32662: remove .shared and mailbox sections

### DIFF
--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32662/Source/system_max32662.c
@@ -32,8 +32,7 @@
 
 extern void (*const __isr_vector[])(void);
 
-uint32_t SystemCoreClock __attribute__((section(".shared")));
-volatile uint32_t mailbox __attribute__((section(".mailbox")));
+uint32_t SystemCoreClock = HIRC_FREQ;
 
 /*
 The libc implementation from GCC 11+ depends on _getpid and _kill in some places.


### PR DESCRIPTION
The .shared and .mailbox sections are for the dual-core parts and don’t exist for the MAX32662

This PR requires to fix below github actions for [PR: add-MAX32662](https://github.com/zephyrproject-rtos/zephyr/pull/73578)

https://github.com/zephyrproject-rtos/zephyr/actions/runs/9317652745/job/25649033826?pr=73578

Added a wrapper function to get UART interrupt enable register, which will be used by zephyr UART driver.

MSDK commit: https://github.com/analogdevicesinc/msdk/pull/1030/commits/e836ab4ad9f36e08af2f8e00c2b2a5f0fe7f6072