### PR TITLE
MSDK: Wrappers: Add function to get interrupt_enable register

### DIFF
--- a/MAX/Include/wrap_max32_uart.h
+++ b/MAX/Include/wrap_max32_uart.h
@@ -213,6 +213,15 @@ static inline void Wrap_MXC_UART_DisableRxDMA(mxc_uart_regs_t *uart)
 
 #endif // defined(CONFIG_SOC_MAX32690) || (CONFIG_SOC_MAX32655)
 
+static inline unsigned int Wrap_MXC_UART_GetRegINTEN(mxc_uart_regs_t *uart)
+{
+#if defined(CONFIG_SOC_MAX32662)
+    return uart->inten;
+#else
+    return uart->int_en;
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Interrupt status need to be checked on zephyr side, 
To provide common interface added a wrapper function due to MAX32662 int_en register named as inten