### PR TITLE
fix(PeriphDrivers): MAX32672 timer issue

### DIFF
--- a/MAX/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
+++ b/MAX/Libraries/PeriphDrivers/Source/TMR/tmr_me21.c
@@ -25,14 +25,14 @@
 
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 {
-    uint8_t tmr_id;
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
     uint8_t clockSource = MXC_TMR_CLK0;
 
     if (cfg == NULL) {
         return E_NULL_PTR;
     }
 
-    MXC_ASSERT((tmr_id = MXC_TMR_GET_IDX(tmr)) >= 0);
+    MXC_ASSERT(tmr_id >= 0);
 
     switch (cfg->clock) {
     case MXC_TMR_EXT_CLK:
@@ -178,8 +178,9 @@ int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 
 void MXC_TMR_Shutdown(mxc_tmr_regs_t *tmr)
 {
-    uint8_t tmr_id;
-    MXC_ASSERT((tmr_id = MXC_TMR_GET_IDX(tmr)) >= 0);
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
+
+    MXC_ASSERT(tmr_id >= 0);
 
     MXC_TMR_RevB_Shutdown((mxc_tmr_revb_regs_t *)tmr);
 


### PR DESCRIPTION
When MXC_ASSERT not enabled timer_id uses without being set for MAX32672 timer driver, this causes run timer issue and compiler gives warnings, see below.
This PR includes fix for this.

![image](https://github.com/user-attachments/assets/ebc20ce1-c4c2-44e0-b07f-42163ca5c96e)

MSDK PR: https://github.com/analogdevicesinc/msdk/pull/1103