### PR TITLE
fix(PeriphDrivers): Fix build warnings for MAX32662 and MAX32672 ADC

### DIFF
--- a/MAX/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
+++ b/MAX/Libraries/PeriphDrivers/Source/ADC/adc_me12.c
@@ -34,9 +34,9 @@
 
 #define MXC_F_MCR_ADC_CFG2_CH 0x3
 
-#define TEMP_FACTOR 530.582f / 4096.0
-#define TEMP_FACTOR1V25 1.25 * TEMP_FACTOR
-#define TEMP_FACTOR2V048 2.048 * TEMP_FACTOR
+#define TEMP_FACTOR (double)530.582f / (double)4096.0f
+#define TEMP_FACTOR1V25 (double)1.25f * TEMP_FACTOR
+#define TEMP_FACTOR2V048 (double)2.048f * TEMP_FACTOR
 
 static void initGPIOForChannel(mxc_adc_chsel_t channel)
 {
@@ -284,7 +284,7 @@ int MXC_ConvertTemperature_ToK(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
 {
     switch (ref) {
     case MXC_ADC_REF_EXT:
-        *temp_k = tempSensor_Readout * TEMP_FACTOR * ext_ref;
+        *temp_k = (double)tempSensor_Readout * (double)TEMP_FACTOR * (double)ext_ref;
         break;
 
     case MXC_ADC_REF_INT_1V25:
@@ -316,7 +316,7 @@ int MXC_ConvertTemperature_ToF(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
                                float *temp)
 {
     if (MXC_ConvertTemperature_ToK(tempSensor_Readout, ref, ext_ref, temp) == E_NO_ERROR) {
-        *temp = ((*temp * 1.8) - 459.67f);
+        *temp = (*temp * 1.8f) - 459.67f;
         return E_NO_ERROR;
     } else {
         return E_BAD_PARAM;

--- a/MAX/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
+++ b/MAX/Libraries/PeriphDrivers/Source/ADC/adc_me21.c
@@ -33,9 +33,9 @@
 
 #define MXC_F_MCR_ADC_CFG2_CH 0x3
 
-#define TEMP_FACTOR 530.582f / 4096.0
-#define TEMP_FACTOR1V25 1.25 * TEMP_FACTOR
-#define TEMP_FACTOR2V048 2.048 * TEMP_FACTOR
+#define TEMP_FACTOR (double)530.582f / (double)4096.0f
+#define TEMP_FACTOR1V25 (double)1.25f * TEMP_FACTOR
+#define TEMP_FACTOR2V048 (double)2.048f * TEMP_FACTOR
 
 static void initGPIOForChannel(mxc_adc_chsel_t channel)
 {
@@ -405,7 +405,7 @@ int MXC_ConvertTemperature_ToK(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
 {
     switch (ref) {
     case MXC_ADC_REF_EXT:
-        *temp_k = tempSensor_Readout * TEMP_FACTOR * ext_ref;
+        *temp_k = (double)tempSensor_Readout * (double)TEMP_FACTOR * (double)ext_ref;
         break;
 
     case MXC_ADC_REF_INT_1V25:
@@ -437,7 +437,7 @@ int MXC_ConvertTemperature_ToF(uint16_t tempSensor_Readout, mxc_adc_refsel_t ref
                                float *temp)
 {
     if (MXC_ConvertTemperature_ToK(tempSensor_Readout, ref, ext_ref, temp) == E_NO_ERROR) {
-        *temp = ((*temp * 1.8) - 459.67f);
+        *temp = (*temp * 1.8f) - 459.67f;
         return E_NO_ERROR;
     } else {
         return E_BAD_PARAM;


### PR DESCRIPTION
Fixed build warnings of ADC for MAX32662 and MAX32672 SoCs.

![image](https://github.com/user-attachments/assets/f25c9d6c-6b29-429a-bb96-65d1c7b54251)

MSDK PR (Merged): https://github.com/analogdevicesinc/msdk/pull/1105
