### PR TITLE
fix(PeriphDrivers): Fix MAX32675 timer warning

### DIFF
--- a/MAX/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
+++ b/MAX/Libraries/PeriphDrivers/Source/TMR/tmr_me16.c
@@ -25,14 +25,14 @@
 
 int MXC_TMR_Init(mxc_tmr_regs_t *tmr, mxc_tmr_cfg_t *cfg, bool init_pins)
 {
-    uint8_t tmr_id;
+    uint8_t tmr_id = MXC_TMR_GET_IDX(tmr);
     uint8_t clockSource = MXC_TMR_CLK0;
 
     if (cfg == NULL) {
         return E_NULL_PTR;
     }
 
-    MXC_ASSERT((tmr_id = MXC_TMR_GET_IDX(tmr)) >= 0);
+    MXC_ASSERT(tmr_id >= 0);
 
     switch (cfg->clock) {
     case MXC_TMR_EXT_CLK:


### PR DESCRIPTION
When MXC_ASSERT not enabled timer_id uses without being set for MAX32675 timer driver, this causes run timer issue and compiler gives warnings, see below.
This PR includes fix for this.

![image](https://github.com/user-attachments/assets/acb959a1-3832-4cbf-b7bc-52ec363158ba)
