### PR TITLE
fix(PeriphDrivers, CMSIS): Fix build warnings and errors

### DIFF
--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32672/Include/max32672.h
@@ -29,13 +29,6 @@
 
 #include <stdint.h>
 
-// TODO(ADI): Remove below after grace period. Temporarily added these includes to resolve errors
-// for grace period before eventually removing support for deprecated features. 10-24-2022
-//>>>
-#include "trimsir_regs.h"
-#include "aes_regs.h"
-//<<<
-
 #ifndef FALSE
 #define FALSE (0)
 #endif
@@ -314,10 +307,6 @@ typedef enum {
 #define MXC_BASE_AES ((uint32_t)0x40207400UL)
 #define MXC_AES ((mxc_aes_regs_t *)MXC_BASE_AES)
 
-// DEPRECATED(10-24-2022): Scheduled for removal.
-typedef __attribute__((deprecated(
-    "Use MXC_AES (mxc_aes_regs_t), not the deprecated MXC_SYS_AES (mxc_sys_aes_regs_t) instance name and struct. 10-24-2022")))
-mxc_aes_regs_t mxc_sys_aes_regs_t;
 #define MXC_SYS_AES ((mxc_sys_aes_regs_t *)MXC_BASE_AES)
 
 /******************************************************************************/

--- a/MAX/Libraries/PeriphDrivers/Source/LP/lp_me12.c
+++ b/MAX/Libraries/PeriphDrivers/Source/LP/lp_me12.c
@@ -58,7 +58,7 @@ void MXC_LP_EnterBackupMode(void)
     // Should never reach this line - device will jump to backup vector on exit from background mode.
 }
 
-void MXC_LP_EnterPowerDownMode(void)
+void MXC_LP_EnterShutDownMode(void)
 {
     MXC_GCR->pm &= ~MXC_F_GCR_PM_MODE;
     MXC_GCR->pm |= MXC_S_GCR_PM_MODE_SHUTDOWN;


### PR DESCRIPTION
This PR addresses below issues.

1. Build tests on MAX32672 boards fail due to redefinition warnings: https://github.com/zephyrproject-rtos/zephyr/issues/79283
2. Shutdown mode function is declared as `MXC_LP_EnterShutDownMode` however it is implemented as `MXC_LP_EnterPowerDownMode` for MAX32662. This could cause undefined reference errors.