### PR TITLE
Fix typo for max32660

### DIFF
--- a/MAX/Include/wrap_max32xxx.h
+++ b/MAX/Include/wrap_max32xxx.h
@@ -36,7 +36,7 @@ extern "C" {
 #elif defined(CONFIG_SOC_MAX32655)
 #include <max32655.h>
 #elif defined(CONFIG_SOC_MAX32660)
-#include <max326660.h>
+#include <max32660.h>
 #elif defined(CONFIG_SOC_MAX32662)
 #include <max32662.h>
 #elif defined(CONFIG_SOC_MAX32665)


### PR DESCRIPTION
max326660.h -> max32660.h