### PR TITLE
Fix MAX32650 zephyr cmake

### DIFF
--- a/MAX/Source/MAX32650/CMakeLists.txt
+++ b/MAX/Source/MAX32650/CMakeLists.txt
@@ -60,7 +60,8 @@ zephyr_library_sources(
      
     ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me10.c
     ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
-    
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+
     ${MSDK_PERIPH_SRC_DIR}/LP/lp_me10.c
     
     ${MSDK_PERIPH_SRC_DIR}/PT/pt_me10.c


### PR DESCRIPTION
This PR adds icc_common.c source file to the MAX32650 Cmake.

This PR is required for https://github.com/zephyrproject-rtos/zephyr/pull/85572