### PR TITLE
Fix HWINFO driver build issue for MAX32650

### DIFF
--- a/MAX/Include/wrap_max32_sys.h
+++ b/MAX/Include/wrap_max32_sys.h
@@ -58,6 +58,16 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
     MXC_SYS_Clock_Div((mxc_sys_system_div_t)div);
 }
 
+static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
+{
+#if defined(CONFIG_SOC_MAX32650)
+    return MXC_SYS_GetUSN(usn, MXC_SYS_USN_LEN);
+#else
+    uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
+    return MXC_SYS_GetUSN(usn, checksum);
+#endif
+}
+
 /*
  *  MAX32690, MAX32655 related mapping
  */
@@ -89,6 +99,13 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 {
     MXC_SYS_SetClockDiv((mxc_sys_system_clock_div_t)div);
+}
+
+static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
+{
+    uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
+
+    return MXC_SYS_GetUSN(usn, checksum);
 }
 
 #endif // part number

--- a/MAX/Libraries/PeriphDrivers/Include/MAX32650/mxc_sys.h
+++ b/MAX/Libraries/PeriphDrivers/Include/MAX32650/mxc_sys.h
@@ -28,7 +28,7 @@
 #define LIBRARIES_PERIPHDRIVERS_INCLUDE_MAX32650_MXC_SYS_H_
 
 /* **** Includes **** */
-#include "max32650.h"
+#include "mxc_device.h"
 #include "uart_regs.h"
 #include "i2c_regs.h"
 #include "pt_regs.h"
@@ -227,6 +227,7 @@ typedef mxc_sys_cfg_t mxc_sys_cfg_usbhs_t;
 
 #define MXC_SYS_SCACHE_CLK 1 // Enable SCACHE CLK
 #define MXC_SYS_TPU_CLK 1 // Enable TPU CLK
+#define MXC_SYS_USN_LEN 13 // Size of the USN
 
 /***** Function Prototypes *****/
 

--- a/MAX/Libraries/PeriphDrivers/Source/SYS/sys_me10.c
+++ b/MAX/Libraries/PeriphDrivers/Source/SYS/sys_me10.c
@@ -350,8 +350,8 @@ int MXC_SYS_Reset_Periph(mxc_sys_reset_t reset)
 /* ************************************************************************** */
 uint8_t MXC_SYS_GetRev(void)
 {
-    uint8_t serialNumber[13];
-    MXC_SYS_GetUSN(serialNumber, 13);
+    uint8_t serialNumber[MXC_SYS_USN_LEN];
+    MXC_SYS_GetUSN(serialNumber, MXC_SYS_USN_LEN);
 
     if ((serialNumber[0] < 0x9F) | ((serialNumber[0] & 0x0F) > 0x09)) {
         // Fail back to the hardware register
@@ -363,7 +363,7 @@ uint8_t MXC_SYS_GetRev(void)
 /* ************************************************************************** */
 int MXC_SYS_GetUSN(uint8_t *serialNumber, int len)
 {
-    if (len != 13) {
+    if (len != MXC_SYS_USN_LEN) {
         return E_BAD_PARAM;
     } else if (serialNumber == NULL) {
         return E_NULL_PTR;


### PR DESCRIPTION
This PR fixes HWINFO driver build issues for MAX32650 boards.

MSDK PR: https://github.com/analogdevicesinc/msdk/pull/1347