### PR TITLE
fix(Other): Zephyr: MAX32650: Add missing LP wrappers (#1344)

### DIFF
--- a/MAX/Include/wrap_max32_lp.h
+++ b/MAX/Include/wrap_max32_lp.h
@@ -29,8 +29,9 @@ extern "C" {
 /*
  *  MAX32665, MAX32666 related mapping
  */
-#if defined(CONFIG_SOC_MAX32665) || (CONFIG_SOC_MAX32666) || (CONFIG_SOC_MAX32670) || \
-    (CONFIG_SOC_MAX32672) || (CONFIG_SOC_MAX32662) || (CONFIG_SOC_MAX32675)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || \
+    defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) || \
+    defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) || defined(CONFIG_SOC_MAX32650)
 
 static inline void Wrap_MXC_LP_EnterLowPowerMode(void)
 {
@@ -49,7 +50,11 @@ static inline void Wrap_MXC_LP_EnterStandbyMode(void)
 
 static inline void Wrap_MXC_LP_EnterPowerDownMode(void)
 {
+#if defined(CONFIG_SOC_MAX32650)
+    MXC_LP_EnterBackupMode();
+#else
     MXC_LP_EnterShutDownMode();
+#endif
 }
 
 /*

--- a/MAX/Include/wrap_max32_sys.h
+++ b/MAX/Include/wrap_max32_sys.h
@@ -74,9 +74,10 @@ static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
 #elif defined(CONFIG_SOC_MAX32690) || defined(CONFIG_SOC_MAX32655) || \
     defined(CONFIG_SOC_MAX32670) || defined(CONFIG_SOC_MAX32672) ||   \
     defined(CONFIG_SOC_MAX32662) || defined(CONFIG_SOC_MAX32675) ||   \
-    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX78002) ||   \
-    defined(CONFIG_SOC_MAX78000)
+    defined(CONFIG_SOC_MAX32680) || defined(CONFIG_SOC_MAX32657) ||   \
+    defined(CONFIG_SOC_MAX78002) || defined(CONFIG_SOC_MAX78000) || defined(CONFIG_SOC_MAX32660)
 
+#if !defined(CONFIG_SOC_MAX32660)
 #define ADI_MAX32_CLK_IPO MXC_SYS_CLOCK_IPO
 #if defined(CONFIG_SOC_MAX78002)
 #define ADI_MAX32_CLK_IPLL MXC_SYS_CLOCK_IPLL
@@ -92,6 +93,11 @@ static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
       (CONFIG_SOC_MAX32675))
 #define ADI_MAX32_CLK_ISO MXC_SYS_CLOCK_ISO
 #endif
+#else
+#define ADI_MAX32_CLK_IPO MXC_SYS_CLOCK_HIRC
+#define ADI_MAX32_CLK_INRO MXC_SYS_CLOCK_NANORING
+#define ADI_MAX32_CLK_ERTCO MXC_SYS_CLOCK_HFXIN
+#endif
 
 #define z_sysclk_prescaler(v) MXC_SYS_CLOCK_DIV_##v
 #define sysclk_prescaler(v) z_sysclk_prescaler(v)
@@ -103,9 +109,13 @@ static inline void Wrap_MXC_SYS_SetClockDiv(int div)
 
 static inline int Wrap_MXC_SYS_GetUSN(uint8_t *usn)
 {
+#if defined(CONFIG_SOC_MAX32660)
+    return MXC_SYS_GetUSN(usn, MXC_SYS_USN_LEN, 0);
+#else
     uint8_t checksum[MXC_SYS_USN_CHECKSUM_LEN];
 
     return MXC_SYS_GetUSN(usn, checksum);
+#endif
 }
 
 #endif // part number

--- a/MAX/Include/wrap_max32_uart.h
+++ b/MAX/Include/wrap_max32_uart.h
@@ -26,9 +26,9 @@
 extern "C" {
 #endif
 
-#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) ||   \
-    defined(CONFIG_SOC_MAX32650)
-#if !defined(CONFIG_SOC_MAX32650)
+#if defined(CONFIG_SOC_MAX32665) || defined(CONFIG_SOC_MAX32666) || \
+    defined(CONFIG_SOC_MAX32650) || defined(CONFIG_SOC_MAX32660)
+#if !defined(CONFIG_SOC_MAX32650) && !defined(CONFIG_SOC_MAX32660)
 // status flags
 #define ADI_MAX32_UART_RX_EMPTY MXC_F_UART_STATUS_RX_EMPTY
 #define ADI_MAX32_UART_TX_EMPTY MXC_F_UART_STATUS_TX_EMPTY
@@ -53,7 +53,7 @@ extern "C" {
 #define ADI_MAX32_UART_INT_BE MXC_F_UART_INT_EN_BREAK // Break Error Interrupt
 #define ADI_MAX32_UART_INT_PE MXC_F_UART_INT_EN_RX_PARITY_ERROR // Parity Error Interrupt
 #define ADI_MAX32_UART_INT_FE MXC_F_UART_INT_EN_RX_FRAME_ERROR // Framing Error Interrupt
-#if !defined(CONFIG_SOC_MAX32650)
+#if !defined(CONFIG_SOC_MAX32650) && !defined(CONFIG_SOC_MAX32660)
 #define ADI_MAX32_UART_INT_RT MXC_F_UART_INT_EN_RX_TIMEOUT // Receive Timeout Interrupt
 #define ADI_MAX32_UART_INT_TX MXC_F_UART_INT_EN_TX_FIFO_THRESH // Transmit Interrupt
 #define ADI_MAX32_UART_INT_RX MXC_F_UART_INT_EN_RX_FIFO_THRESH // Receive Interrupt
@@ -93,7 +93,7 @@ static inline int Wrap_MXC_UART_Init(mxc_uart_regs_t *uart)
         return ret;
     }
 
-#if defined(CONFIG_SOC_MAX32650)
+#if defined(CONFIG_SOC_MAX32650) || defined(CONFIG_SOC_MAX32660)
     uart->ctrl0 |= MXC_F_UART_CTRL0_ENABLE;
 #else
     uart->ctrl |= MXC_F_UART_CTRL_ENABLE;

--- a/MAX/Include/wrap_max32xxx.h
+++ b/MAX/Include/wrap_max32xxx.h
@@ -36,7 +36,7 @@ extern "C" {
 #elif defined(CONFIG_SOC_MAX32655)
 #include <max32655.h>
 #elif defined(CONFIG_SOC_MAX32660)
-#include <max326660.h>
+#include <max32660.h>
 #elif defined(CONFIG_SOC_MAX32662)
 #include <max32662.h>
 #elif defined(CONFIG_SOC_MAX32665)

--- a/MAX/Libraries/CMSIS/Device/Maxim/MAX32660/Include/uart_regs.h
+++ b/MAX/Libraries/CMSIS/Device/Maxim/MAX32660/Include/uart_regs.h
@@ -366,11 +366,11 @@ typedef struct {
 #define MXC_F_UART_DMA_RXDMA_EN_POS                    1 /**< DMA_RXDMA_EN Position */
 #define MXC_F_UART_DMA_RXDMA_EN                        ((uint32_t)(0x1UL << MXC_F_UART_DMA_RXDMA_EN_POS)) /**< DMA_RXDMA_EN Mask */
 
-#define MXC_F_UART_DMA_TXDMA_LVL_POS                   8 /**< DMA_TXDMA_LVL Position */
-#define MXC_F_UART_DMA_TXDMA_LVL                       ((uint32_t)(0x3FUL << MXC_F_UART_DMA_TXDMA_LVL_POS)) /**< DMA_TXDMA_LVL Mask */
+#define MXC_F_UART_DMA_TXDMA_LEVEL_POS                   8 /**< DMA_TXDMA_LVL Position */
+#define MXC_F_UART_DMA_TXDMA_LEVEL                       ((uint32_t)(0x3FUL << MXC_F_UART_DMA_TXDMA_LEVEL_POS)) /**< DMA_TXDMA_LVL Mask */
 
-#define MXC_F_UART_DMA_RXDMA_LVL_POS                   16 /**< DMA_RXDMA_LVL Position */
-#define MXC_F_UART_DMA_RXDMA_LVL                       ((uint32_t)(0x3FUL << MXC_F_UART_DMA_RXDMA_LVL_POS)) /**< DMA_RXDMA_LVL Mask */
+#define MXC_F_UART_DMA_RXDMA_LEVEL_POS                   16 /**< DMA_RXDMA_LVL Position */
+#define MXC_F_UART_DMA_RXDMA_LEVEL                       ((uint32_t)(0x3FUL << MXC_F_UART_DMA_RXDMA_LEVEL_POS)) /**< DMA_RXDMA_LVL Mask */
 
 /**@} end of group UART_DMA_Register */
 

--- a/MAX/Source/MAX32660/CMakeLists.txt
+++ b/MAX/Source/MAX32660/CMakeLists.txt
@@ -1,0 +1,130 @@
+##############################################################################
+#
+# Copyright (C) 2025 Analog Devices, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+##############################################################################
+
+
+if(NOT TARGET_REV)
+  # Default version A1, not actively use in driver but requires to be defined.
+  zephyr_compile_definitions(-DTARGET_REV=0x4131)
+endif()
+
+zephyr_include_directories(
+    ${MSDK_PERIPH_SRC_DIR}/SYS
+    ${MSDK_PERIPH_SRC_DIR}/DMA
+    ${MSDK_PERIPH_SRC_DIR}/FLC
+    ${MSDK_PERIPH_SRC_DIR}/GPIO
+    ${MSDK_PERIPH_SRC_DIR}/I2C
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS
+    ${MSDK_PERIPH_SRC_DIR}/ICC
+    ${MSDK_PERIPH_SRC_DIR}/LP
+    ${MSDK_PERIPH_SRC_DIR}/RTC
+    ${MSDK_PERIPH_SRC_DIR}/SPI
+    ${MSDK_PERIPH_SRC_DIR}/TMR
+    ${MSDK_PERIPH_SRC_DIR}/UART
+    ${MSDK_PERIPH_SRC_DIR}/WDT
+)
+
+zephyr_library_sources(
+    ./max32xxx_system.c
+
+    ${MSDK_CMSIS_DIR}/Source/system_max32660.c
+
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_assert.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_delay.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/mxc_lock.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/pins_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/SYS/sys_me11.c
+     
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_reva.c
+    ${MSDK_PERIPH_SRC_DIR}/ICC/icc_common.c
+
+    ${MSDK_PERIPH_SRC_DIR}/LP/lp_me11.c
+
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/DMA/dma_reva.c
+)
+
+if (CONFIG_UART_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_common.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/UART/uart_reva.c
+)
+endif()
+
+if (CONFIG_GPIO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_common.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/GPIO/gpio_reva.c
+)
+endif()
+
+if (CONFIG_SPI_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/SPI/spi_reva1.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/spimss_reva1.c
+)
+endif()
+
+if (CONFIG_I2C_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/I2C/i2c_reva.c
+)
+endif()
+
+if (CONFIG_WDT_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_common.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/WDT/wdt_reva.c
+)
+endif()
+
+if (CONFIG_RTC_MAX32 OR CONFIG_COUNTER_RTC_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/RTC/rtc_reva.c
+)
+endif()
+
+if (CONFIG_SOC_FLASH_MAX32 OR CONFIG_HWINFO_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_common.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/FLC/flc_reva.c
+)
+endif()
+
+if (CONFIG_PWM_MAX32 OR CONFIG_TIMER_MAX32 OR CONFIG_COUNTER_TIMER_MAX32) 
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_common.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/TMR/tmr_reva.c
+)
+endif()
+
+if (CONFIG_I2S_MAX32)
+zephyr_library_sources(
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/i2s_me11.c
+    ${MSDK_PERIPH_SRC_DIR}/SPIMSS/i2s_reva.c
+)
+endif()

--- a/MAX/Source/MAX32660/max32xxx_system.c
+++ b/MAX/Source/MAX32660/max32xxx_system.c
@@ -1,0 +1,42 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2025 Analog Devices, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "max32660.h"
+#include "mxc_sys.h"
+#include "wdt_regs.h"
+
+/* 
+ * This function is called during boot up.
+ */
+void max32xx_system_init(void)
+{
+    MXC_WDT0->ctrl &=
+        ~MXC_F_WDT_CTRL_WDT_EN; /* Turn off watchdog. Application can re-enable as needed. */
+
+    /* Disable clocks to peripherals by default to reduce power */
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_DMA);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_SPI0);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_SPI1);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_UART0);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_UART1);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_I2C0);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TMR0);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TMR1);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_TMR2);
+    MXC_SYS_ClockDisable(MXC_SYS_PERIPH_CLOCK_I2C1);
+}


### PR DESCRIPTION
This PR adds MAX32660 hal files for zephyr support and adds LP solution for MAX32650
SoC.