### PR TITLE
chore(PeriphDrivers): Replace pow() with left shift in UART drivers

### DIFF
--- a/MAX/Libraries/PeriphDrivers/Source/UART/uart_me15.c
+++ b/MAX/Libraries/PeriphDrivers/Source/UART/uart_me15.c
@@ -18,7 +18,6 @@
  *
  ******************************************************************************/
 
-#include <math.h>
 #include "uart.h"
 #include "mxc_device.h"
 #include "mxc_pins.h"
@@ -188,7 +187,7 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     case MXC_UART_AOD_CLK:
         aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >>
                       MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
-        clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
+        clock_freq = PeripheralClock / (4 * (1 << aon_clk_div));
         break;
 
     default:

--- a/MAX/Libraries/PeriphDrivers/Source/UART/uart_me16.c
+++ b/MAX/Libraries/PeriphDrivers/Source/UART/uart_me16.c
@@ -21,7 +21,6 @@
 #pragma diag_suppress 68 // integer conversion resulted in a change of sign
 #endif
 
-#include <math.h>
 #include "uart.h"
 #include "mxc_device.h"
 #include "mxc_pins.h"

--- a/MAX/Libraries/PeriphDrivers/Source/UART/uart_me21.c
+++ b/MAX/Libraries/PeriphDrivers/Source/UART/uart_me21.c
@@ -18,7 +18,6 @@
  *
  ******************************************************************************/
 
-#include <math.h>
 #include "uart.h"
 #include "mxc_device.h"
 #include "mxc_pins.h"
@@ -206,7 +205,7 @@ int MXC_UART_SetFrequency(mxc_uart_regs_t *uart, unsigned int baud, mxc_uart_clo
     case MXC_UART_AOD_CLK:
         aon_clk_div = (MXC_GCR->pclkdiv & MXC_F_GCR_PCLKDIV_AON_CLKDIV) >>
                       MXC_F_GCR_PCLKDIV_AON_CLKDIV_POS;
-        clock_freq = PeripheralClock / (4 * (pow(2, aon_clk_div)));
+        clock_freq = PeripheralClock / (4 * (1 << aon_clk_div));
         break;
     default:
         return E_BAD_PARAM;


### PR DESCRIPTION
### Description
Since aon_clk_div is an integer, pow(2, aon_clk_div) can be replaced with (1 << aon_clk_div) in MXC_UART_SetFrequency. This eliminates the need to include <math.h> in UART driver.

#### Motive
Zephyr uses its own math library which provides an implementation of pow(). When running batch tests, however, it switches to a minimal implementation of the C library that does not include the pow() function. As a result, UART drivers cannot be compiled and tests fail.

Copy of https://github.com/analogdevicesinc/msdk/pull/1217.