### PR TITLE
feat(Other, PeriphDrivers): Add ADC support for Zephyr stream

### DIFF
--- a/MAX/Include/wrap_max32_adc.h
+++ b/MAX/Include/wrap_max32_adc.h
@@ -285,6 +285,14 @@ static inline int Wrap_MXC_ADC_StartConversionAsync(uint32_t *sample_channels,
     return MXC_ADC_StartConversionAsync(callback);
 }
 
+static inline int Wrap_MXC_ADC_StartConversionAsyncStream(uint32_t *sample_channels,
+                mxc_adc_complete_cb_t callback)
+{
+    MXC_ADC_FIFO_Threshold_Config(MAX_ADC_FIFO_LEN >> 1);
+    Wrap_MXC_ADC_ChannelSelect(sample_channels);
+    return MXC_ADC_StartConversionAsyncStream(callback);
+}
+
 static inline void Wrap_MXC_ADC_GetData(uint16_t **outdata)
 {
     mxc_adc_regs_t *adc = MXC_ADC;

--- a/MAX/Libraries/PeriphDrivers/Include/MAX32690/adc.h
+++ b/MAX/Libraries/PeriphDrivers/Include/MAX32690/adc.h
@@ -332,6 +332,19 @@ int MXC_ADC_StartConversion(void);
 int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback);
 
 /**
+ * @brief   Perform a stream conversion on a specific channel
+ * @note    The channel must be configured separately
+ *          The ADC interrupt must be enabled and MXC_ADC_Handler() called in the ISR
+ *          places data in the error parameter of the callback function
+ *          Has different flags but behaves same as MXC_ADC_StartConversionAsync.
+ *
+ * @param   callback the function to call when the conversion is complete
+ *
+ * @return  Success/Fail, see \ref MXC_Error_Codes for a list of return codes.
+ */
+int MXC_ADC_StartConversionAsyncStream(mxc_adc_complete_cb_t callback);
+
+/**
  * @brief   Perform a conversion on a specific channel using a DMA transfer.
  *          DMA channel must be acquired using \ref MXC_DMA_AcquireChannel and should
  *          be passed to this function via "dma_channel" member of "req" input struct.
@@ -355,6 +368,15 @@ int MXC_ADC_StartConversionDMA(mxc_adc_conversion_req_t *req, int *data,
  */
 
 int MXC_ADC_Handler(void);
+
+/**
+ * @brief   Free the continous conversion resources.
+ * @note    Free the callback without need to change current
+ *          Revb Handler to keep backward compatibility.
+ *
+ * @param   None
+ */
+void MXC_ADC_Free(void);
 
 /**
  * @brief   Selects the analog input divider.

--- a/MAX/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
+++ b/MAX/Libraries/PeriphDrivers/Source/ADC/adc_me18.c
@@ -174,6 +174,11 @@ int MXC_ADC_StartConversionAsync(mxc_adc_complete_cb_t callback)
     return MXC_ADC_RevB_StartConversionAsync((mxc_adc_revb_regs_t *)MXC_ADC, callback);
 }
 
+int MXC_ADC_StartConversionAsyncStream(mxc_adc_complete_cb_t callback)
+{
+    return MXC_ADC_RevB_StartConversionAsyncStream((mxc_adc_revb_regs_t *)MXC_ADC, callback);
+}
+
 int MXC_ADC_StartConversionDMA(mxc_adc_conversion_req_t *req, int *data, void (*callback)(int, int))
 {
     return MXC_ADC_RevB_StartConversionDMA((mxc_adc_revb_regs_t *)MXC_ADC, req, data, callback);
@@ -182,6 +187,11 @@ int MXC_ADC_StartConversionDMA(mxc_adc_conversion_req_t *req, int *data, void (*
 int MXC_ADC_Handler(void)
 {
     return MXC_ADC_RevB_Handler((mxc_adc_revb_regs_t *)MXC_ADC);
+}
+
+void MXC_ADC_Free(void)
+{
+    MXC_ADC_RevB_Free((mxc_adc_revb_regs_t *)MXC_ADC);
 }
 
 int MXC_ADC_GetData(int *outdata)

--- a/MAX/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
+++ b/MAX/Libraries/PeriphDrivers/Source/ADC/adc_revb.c
@@ -203,6 +203,25 @@ int MXC_ADC_RevB_StartConversionAsync(mxc_adc_revb_regs_t *adc, mxc_adc_complete
     return E_NO_ERROR;
 }
 
+int MXC_ADC_RevB_StartConversionAsyncStream(mxc_adc_revb_regs_t *adc, mxc_adc_complete_cb_t callback)
+{
+    if (callback == NULL) {
+        return E_BAD_PARAM;
+    }
+
+    adc->fifodmactrl |= MXC_F_ADC_REVB_FIFODMACTRL_FLUSH; //Flush data FIFO
+
+    MXC_ADC_RevB_ClearFlags(adc, ADC_IF_MASK);
+
+    while (MXC_GetLock((uint32_t *)&async_callback, (uint32_t)callback) != E_NO_ERROR) {}
+
+    MXC_ADC_RevB_EnableInt(adc, MXC_F_ADC_REVB_INTEN_FIFO_LVL);
+
+    adc->ctrl1 |= MXC_F_ADC_REVB_CTRL1_START | MXC_F_ADC_REVB_CTRL1_CNV_MODE;
+
+    return E_NO_ERROR;
+}
+
 int MXC_ADC_RevB_StartConversionDMA(mxc_adc_revb_regs_t *adc, mxc_adc_conversion_req_t *req,
                                     int *data, void (*callback)(int, int))
 {
@@ -299,6 +318,16 @@ int MXC_ADC_RevB_Handler(mxc_adc_revb_regs_t *adc)
     return E_NO_ERROR;
 }
 
+void MXC_ADC_RevB_Free(mxc_adc_revb_regs_t *adc)
+{
+    if ((adc->ctrl1 & MXC_F_ADC_REVB_CTRL1_CNV_MODE)) {
+        MXC_ADC_RevB_DisableInt(adc, (MXC_F_ADC_REVB_INTFL_SEQ_DONE |
+            MXC_F_ADC_REVB_INTFL_CONV_DONE |
+            MXC_F_ADC_REVB_INTEN_FIFO_LVL));
+
+        MXC_FreeLock((uint32_t *)&async_callback);
+    }
+}
 int MXC_ADC_RevB_GetData(mxc_adc_revb_regs_t *adc, int *outdata)
 {
     uint32_t loop_counter, length;

--- a/MAX/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
+++ b/MAX/Libraries/PeriphDrivers/Source/ADC/adc_revb.h
@@ -57,6 +57,8 @@ int MXC_ADC_RevB_StartConversion(mxc_adc_revb_regs_t *adcq);
 
 int MXC_ADC_RevB_StartConversionAsync(mxc_adc_revb_regs_t *adc, mxc_adc_complete_cb_t callback);
 
+int MXC_ADC_RevB_StartConversionAsyncStream(mxc_adc_revb_regs_t *adc, mxc_adc_complete_cb_t callback);
+
 int MXC_ADC_RevB_StartConversionDMA(mxc_adc_revb_regs_t *adc, mxc_adc_conversion_req_t *req,
                                     int *data, void (*callback)(int, int));
 
@@ -71,6 +73,8 @@ void MXC_ADC_RevB_TS_SelectEnable(mxc_adc_revb_regs_t *adc);
 void MXC_ADC_RevB_TS_SelectDisable(mxc_adc_revb_regs_t *adc);
 
 int MXC_ADC_RevB_GetData(mxc_adc_revb_regs_t *adc, int *outdata);
+
+void MXC_ADC_RevB_Free(mxc_adc_revb_regs_t *adc);
 
 uint16_t MXC_ADC_RevB_FIFO_Level(mxc_adc_revb_regs_t *adc);
 


### PR DESCRIPTION
Added functions are all new in order to not break anything existing.
They are modification of existing functionalities but with different
flags in order to achieve Zephyr stream with MAX32690 ADC.

