### PR TITLE
Fix: DMA: shift enum values to corresponding bit positions

### DIFF
--- a/MAX/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
+++ b/MAX/Libraries/PeriphDrivers/Source/DMA/dma_reva.c
@@ -203,8 +203,10 @@ int MXC_DMA_RevA_AdvConfigChannel(mxc_dma_adv_config_t advConfig)
         dma_resource[advConfig.ch].regs->ctrl &= ~(0x1F00FC0C); // Clear all fields we set here
         /* Designed to be safe, not speedy. Should not be called often */
         dma_resource[advConfig.ch].regs->ctrl |=
-            ((advConfig.reqwait_en ? MXC_F_DMA_REVA_CTRL_TO_WAIT : 0) | advConfig.prio |
-             advConfig.tosel | advConfig.pssel |
+            ((advConfig.reqwait_en ? MXC_F_DMA_REVA_CTRL_TO_WAIT : 0) | 
+             (advConfig.prio << MXC_F_DMA_REVA_CTRL_PRI_POS) |
+             (advConfig.tosel << MXC_F_DMA_REVA_CTRL_TO_PER_POS) | 
+             (advConfig.pssel << MXC_F_DMA_REVA_CTRL_TO_CLKDIV_POS) |
              (((advConfig.burst_size - 1) << MXC_F_DMA_REVA_CTRL_BURST_SIZE_POS) &
               MXC_F_DMA_REVA_CTRL_BURST_SIZE));
     } else {


### PR DESCRIPTION
Description:
Or'ing non-zero enum values (priority/timeout/presaler) could cause undefined behavior due to ctrl config corruption. This PR fixes it by shifting them to proper bit positions.