### PR TITLE
feat(PeriphDrivers): Add ECC-aware flash read function for MAX32657

### DIFF
--- a/MAX/Include/wrap_max32_flc.h
+++ b/MAX/Include/wrap_max32_flc.h
@@ -49,6 +49,28 @@ static inline int Wrap_MXC_FLC_Write(uint32_t address, uint32_t length, uint32_t
 
 #endif // part number
 
+#if defined(CONFIG_SOC_MAX32657)
+
+static inline int Wrap_MXC_FLC_Read(uint32_t address, void *buffer, int len)
+{
+    int ret = 0;
+
+    ret = MXC_FLC_ReadECC(address, buffer, len);
+
+    return ret;
+}
+
+#else
+
+static inline int Wrap_MXC_FLC_Read(uint32_t address, void *buffer, int len)
+{
+    MXC_FLC_Read(address, buffer, len);
+
+    return 0;
+}
+
+#endif /* CONFIG_SOC_MAX32657 */
+
 #ifdef __cplusplus
 }
 #endif

--- a/MAX/Libraries/PeriphDrivers/Include/MAX32657/flc.h
+++ b/MAX/Libraries/PeriphDrivers/Include/MAX32657/flc.h
@@ -89,6 +89,22 @@ int MXC_FLC_PageErase(uint32_t address);
 void MXC_FLC_Read(int address, void *buffer, int len);
 
 /**
+ * @brief       Read Data out of flash from an address and check for ECC errors.
+ * @details     If ECC errors are detected, data read is checked against ECC bits
+ *              to make sure the error is not caused by an unwritten part of the
+ *              memory.   
+ * @note        This function must be executed from RAM. Cache must be disabled or
+ *              the address must be in a noncacheable region.
+ * 
+ * @param       address  The address to read from. 
+ * @param       buffer   The buffer to read the data into.
+ * @param       len      The length of the buffer.
+ * @return      #E_NO_ERROR If function is successful.
+ *              #E_BAD_STATE If the ECC error is not correctable.
+ */
+int MXC_FLC_ReadECC(uint32_t address, void *buffer, int len);
+
+/**
  * @brief      Writes data to flash.
  * @note       This function must be executed from RAM.
  * @param      address  Address in flash to start writing from.


### PR DESCRIPTION
Add a new flash read function that handles ECC errors when an erased page is read. Reads are aligned to line buffer size, 256 bits, as ECC data is calculated for a whole line regardless of the read size.

https://github.com/analogdevicesinc/msdk/pull/1374