### PR TITLE
fix(USB): Service EP0 (control) OUT & SETUP transactions

### DIFF
--- a/MAX/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/MAX/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -795,21 +795,19 @@ void MXC_USB_IrqHandler(maxusb_usbio_events_t *evt)
             aborted = 1;
         }
         /* Now, check for a SETUP packet */
-        if (!aborted) {
-            if ((setup_phase == SETUP_IDLE) && (MXC_USBHS->csr0 & MXC_F_USBHS_CSR0_OUTPKTRDY)) {
-                /* Flag that we got a SETUP packet */
-                evt->sudav = 1;
-                /* Remove this from the IN flags so that it is not erroneously processed as data */
+        if ((setup_phase == SETUP_IDLE) && (MXC_USBHS->csr0 & MXC_F_USBHS_CSR0_OUTPKTRDY)) {
+            /* Flag that we got a SETUP packet */
+            evt->sudav = 1;
+            /* Remove this from the IN flags so that it is not erroneously processed as data */
+            in_flags &= ~MXC_F_USBHS_INTRIN_EP0_IN_INT;
+        } else if (!aborted) {
+            /* Otherwise, we are in endpoint 0 data IN/OUT */
+            /* Fix interrupt flags so that OUTs are processed properly */
+            if (setup_phase == SETUP_DATA_OUT) {
                 in_flags &= ~MXC_F_USBHS_INTRIN_EP0_IN_INT;
-            } else {
-                /* Otherwise, we are in endpoint 0 data IN/OUT */
-                /* Fix interrupt flags so that OUTs are processed properly */
-                if (setup_phase == SETUP_DATA_OUT) {
-                    in_flags &= ~MXC_F_USBHS_INTRIN_EP0_IN_INT;
-                    out_flags |= MXC_F_USBHS_INTRIN_EP0_IN_INT;
-                }
-                /* SETUP_NODATA is silently ignored by event_in_data() right now.. could fix this later */
+                out_flags |= MXC_F_USBHS_INTRIN_EP0_IN_INT;
             }
+            /* SETUP_NODATA is silently ignored by event_in_data() right now.. could fix this later */
         }
     }
     /* do cleanup in cases of bus reset */

--- a/MAX/Libraries/MAXUSB/src/core/musbhsfc/usb.c
+++ b/MAX/Libraries/MAXUSB/src/core/musbhsfc/usb.c
@@ -1132,12 +1132,12 @@ int MXC_USB_ReadEndpoint(MXC_USB_Req_t *req)
     /* Select endpoint */
     MXC_USBHS->index = ep;
 
-    /* Since the OUT interrupt for EP 0 doesn't really exist, only do this logic for other endpoints */
+    /* EP0 and other endpoints have different status/count/int register sets */
     if (ep) {
         armed = 0;
 
         if (!armed) {
-            /* EP0 or no free DMA channel found, fall back to PIO */
+            /* No free DMA channel found, fall back to PIO */
 
             /* See if data already in FIFO for this EP */
             if (MXC_USBHS->outcsrl & MXC_F_USBHS_OUTCSRL_OUTPKTRDY) {
@@ -1169,6 +1169,37 @@ int MXC_USB_ReadEndpoint(MXC_USB_Req_t *req)
                 /* No data, will need an interrupt to service later */
                 MXC_USBHS->introuten |= (1 << ep);
             }
+        }
+    } else {
+        /* See if data already in FIFO for EP0 */
+        if (MXC_USBHS->csr0 & MXC_F_USBHS_CSR0_OUTPKTRDY) {
+            reqsize = MXC_USBHS->count0;
+            if (reqsize > (req->reqlen - req->actlen)) {
+                reqsize = (req->reqlen - req->actlen);
+            }
+
+            unload_fifo(&req->data[req->actlen], get_fifo_ptr(ep), reqsize);
+
+            req->actlen += reqsize;
+
+            /* Signal to H/W that FIFO has been read */
+            MXC_USBHS->csr0 |= MXC_F_USBHS_CSR0_SERV_OUTPKTRDY;
+            if ((req->type == MAXUSB_TYPE_PKT) || (req->actlen == req->reqlen)) {
+                /* Done with request, callback fires if configured */
+                MXC_SYS_Crit_Exit();
+                MXC_USB_Request[ep] = NULL;
+
+                if (req->callback) {
+                    req->callback(req->cbdata);
+                }
+                return 0;
+            } else {
+                /* Not done, more data requested */
+                MXC_USBHS->intrinen |= MXC_F_USBHS_INTRINEN_EP0_INT_EN;
+            }
+        } else {
+            /* No data, will need an interrupt to service later */
+            MXC_USBHS->intrinen |= MXC_F_USBHS_INTRINEN_EP0_INT_EN;
         }
     }
 


### PR DESCRIPTION
MXC_USB_ReadEndpoint currently only services non-control endpoints. The justification for this was that EP0 out doesn't have an OUT interrupt. The issue with this is that ReadEndpoint is just not servicing Control OUT transactions as a result, which breaks the enumeration / configuration process.

This PR adds handling for EP0 OUT so that control transactions can proceed properly without manual intervention. Otherwise some manual servicing of EP0 out transactions would be needed on the part of higher-level drivers. 

An additional commit was added to fix a problem where a new SETUP event would not be handled if it was aborting other DATA / STATUS transactions on EP0. This commit switches the order of checks in the IRQ Handler so that the new SETUP is serviced before the (!aborted) check for e.g. a DATA transfer. 