### PR TITLE
modules: hal_adi: avoid shadowing CMSIS_6 headers on Arm

### DIFF
--- a/MAX/CMakeLists.txt
+++ b/MAX/CMakeLists.txt
@@ -48,10 +48,13 @@ set(MSDK_PERIPH_INC_DIR  ${MSDK_PERIPH_DIR}/Include/${TARGET_UC})
 zephyr_include_directories(
     ./Include
     ./Source/${TARGET_UC}
-    ${MSDK_LIBRARY_DIR}/CMSIS/Include
     ${MSDK_CMSIS_DIR}/Include
     ${MSDK_PERIPH_INC_DIR}
 )
+
+if(CONFIG_RISCV)
+  zephyr_include_directories(${MSDK_LIBRARY_DIR}/CMSIS/Include)
+endif()
 
 if (CONFIG_UDC_MAX32)
     zephyr_compile_definitions(


### PR DESCRIPTION
The ADI/MAX HAL adds its bundled Libraries/CMSIS/Include directory to the global include path. For Arm builds this can shadow the CMSIS_6 Core headers provided by Zephyr's cmsis_6 module, causing Zephyr to include stale or incompatible core_cm*.h headers.

Keep the device-specific CMSIS include directory for MAX targets, but only add the bundled generic CMSIS include directory for RISC-V builds where it is needed by the ADI/MAX SDK integration.